### PR TITLE
Fix static asset middleware for .NET 8

### DIFF
--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -17,11 +17,10 @@ app.UseRouting();
 
 app.UseAuthorization();
 
-app.MapStaticAssets();
+app.UseStaticFiles();
 
 app.MapControllerRoute(
     name: "default",
-    pattern: "{controller=Home}/{action=Index}/{id?}")
-    .WithStaticAssets();
+    pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();


### PR DESCRIPTION
### Motivation
- Replace unsupported pipeline calls that cause build/runtime issues on the project `net8.0` target so static files are served correctly at runtime.

### Description
- Replace `MapStaticAssets()` with `UseStaticFiles()` and remove the `.WithStaticAssets()` call from the default controller route in `src/Web/Program.cs` to restore the standard ASP.NET Core static file pipeline.

### Testing
- Attempted to run `dotnet test` but the `dotnet` CLI is not available in the execution environment, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6849b0648323871f8a053efcef79)