### PR TITLE
docs: add immediate next-step guidance for app execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Cimex-Booking is an AI-assisted ASP.NET Core MVC project for a solo exterminatio
 - **M5**: Admin operations portal
 - **M6**: Deployment and operational hardening
 - **M7**: SaaS readiness and tenant boundaries
+
+## Execution guidance
+
+- See `docs/next-step.md` for the recommended immediate implementation step and completion criteria.

--- a/docs/next-step.md
+++ b/docs/next-step.md
@@ -1,0 +1,23 @@
+# Immediate Next Step Recommendation
+
+## Recommended next step
+
+Start **M2 — Domain and Data Foundation** by implementing the first vertical slice:
+
+1. Create a `BookingRequest` domain entity in `src/Domain` with status, customer contact, requested service date, and audit timestamps.
+2. Add an EF Core `DbContext` in `src/Infrastructure` and map the entity.
+3. Wire PostgreSQL connection settings in `src/Web/appsettings*.json` and dependency injection in `Program.cs`.
+4. Add the first migration and verify the app can create/update the database.
+
+## Why this should be next
+
+- The repository already has baseline architecture and documentation in place (M1 outcomes).
+- Domain and persistence are prerequisites for both public booking intake (M4) and admin operations (M5).
+- Identity setup (M3) is easier to validate once there is real data to protect.
+
+## Definition of done for this step
+
+- `BookingRequest` entity and supporting enums/value objects are committed.
+- EF Core migration is generated and checked in.
+- App starts successfully with database connectivity configured by environment.
+- At least one automated test validates domain rules for booking creation.


### PR DESCRIPTION
### Motivation

- Provide a clear, discoverable recommendation for the immediate next implementation step (start M2 — Domain and Data Foundation) to help contributors pick up work and unblock downstream milestones.

### Description

- Add `docs/next-step.md` containing a concrete vertical-slice plan (create `BookingRequest` entity, add EF Core `DbContext`, wire PostgreSQL, generate first migration) and add an `Execution guidance` section to `README.md` that links to the new doc.

### Testing

- Attempted to run `dotnet test`, but `dotnet` is not available in this environment so no automated tests were executed (the `dotnet test` command returned `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b693f9e7c8323ac8670405a1b2327)